### PR TITLE
🐛 Fix: Fim de semana para recorrências mensais e refatoração do código

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,19 @@
+{
+    "env": {
+        "commonjs": true,
+        "es6": true,
+        "node": true
+    },
+    "extends": [
+        "standard"
+    ],
+    "globals": {
+        "Atomics": "readonly",
+        "SharedArrayBuffer": "readonly"
+    },
+    "parserOptions": {
+        "ecmaVersion": 2018
+    },
+    "rules": {
+    }
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,107 +1,94 @@
-'use strict';
-const moment = require('moment');
-const _ = require('underscore')._;
+'use strict'
+const moment = require('moment')
+const _ = require('underscore')._
 
 if (!Number.prototype.pad) {
-    Number.prototype.pad = function (size) {
-        var s = String(this);
-        while (s.length < (size || 2)) {
-            s = "0" + s;
-        }
-        return s;
-    };
+  Number.prototype.pad = function (size) {
+    var s = String(this)
+    while (s.length < (size || 2)) {
+      s = '0' + s
+    }
+    return s
+  }
 }
 
 exports = module.exports = function (config) {
+  config.options = config.options || {}
+  config.options.format = config.options.format || 'YYYY-MM-DD'
+  config.iterations = config.iterations || 50
+  config.limit = config.limit || null
+  config.start = moment(config.start)
+  config.end = config.end ? moment(config.end) : null
 
-    config.options = config.options || {};
-    config.options.format = config.options.format || 'YYYY-MM-DD';
-    config.iterations = config.iterations || 50;
-    config.limit = config.limit || null;
-    config.start = moment(config.start);
-    config.end = config.end ? moment(config.end) : null;
+  const occurrence = config.start
 
-    let occurrence = config.start;
-
-    if (config.dayOfMonth) {
-
-        while (true) {
-
-            if (occurrence.date() === config.dayOfMonth) {
-                break;
-            }
-
-            occurrence.add(1, 'd');
-        }
-    }
-
-    if (config.weekday) {
-
-        while (true) {
-            if (occurrence.weekday() === config.weekday) {
-                break;
-            }
-            occurrence.add(1, 'd');
-        }
-    }
-
-    let results = [];
-    let iterations = 0;
-    let lastBaseOccurrence = null;
-
+  if (config.dayOfMonth) {
     while (true) {
+      if (occurrence.date() === config.dayOfMonth) {
+        break
+      }
 
-        iterations++;
+      occurrence.add(1, 'd')
+    }
+  }
 
-        let result = occurrence.format(config.options.format);
+  if (config.weekday) {
+    while (true) {
+      if (occurrence.weekday() === config.weekday) {
+        break
+      }
+      occurrence.add(1, 'd')
+    }
+  }
 
-        if (config.options.skipWeekend) {
+  const results = []
+  let iterations = 0
+  let lastBaseOccurrence = null
 
-            if (occurrence.weekday() === 0) {
-                result = occurrence.clone().add(1, 'd').format(config.options.format);
-            }
+  while (true) {
+    iterations++
 
-            if (occurrence.weekday() === 6) {
-                result = occurrence.clone().add(2, 'd').format(config.options.format);
-            }
-        }
+    let result = occurrence
+    if (config.dayOfMonth) {
+      const expectedDate = moment(result).format('YYYY-MM-') + config.dayOfMonth.pad(2)
+      result = moment(expectedDate)
+    }
+    if (config.options.skipWeekend && result.isValid()) {
+      if (result.weekday() === 0) {
+        result = result.clone().add(1, 'd')
+      }
 
-        if (config.dayOfMonth) {
-
-            var isFebruary = (occurrence.month() == 1);
-            if (isFebruary && config.dayOfMonth > 28) {
-                result = moment(result).endOf('month').format(config.options.format);
-            } else {
-                var expectedDate = moment(result).format('YYYY-MM-') + config.dayOfMonth.pad(2);
-                result = moment(expectedDate).format(config.options.format);
-            }
-        }
-
-        if (!_.contains(results, result)) {
-            results.push(result);
-        }
-        
-        lastBaseOccurrence = occurrence.format(config.options.format);
-        occurrence.add(config.every, config.interval);
-
-        if (config.end !== null && occurrence.isAfter(config.end)) {
-            break;
-        }
-
-        if (config.limit !== null && results.length >= config.limit) {
-            break;
-        }
-
-        if (iterations >= config.iterations) {
-            break;
-        }
+      if (result.weekday() === 6) {
+        result = result.clone().add(2, 'd')
+      }
     }
 
-    return {
-        results: results,
-        iterations: iterations,
-        info: { 
-            lastBaseOccurrence: lastBaseOccurrence
-        }
+    const formattedResult = result.format(config.options.format)
+    if (!_.contains(results, formattedResult) && result.isValid()) {
+      results.push(formattedResult)
     }
-};
+
+    lastBaseOccurrence = occurrence.format(config.options.format)
+    occurrence.add(config.every, config.interval)
+
+    if (config.end !== null && occurrence.isAfter(config.end)) {
+      break
+    }
+
+    if (config.limit !== null && results.length >= config.limit) {
+      break
+    }
+
+    if (iterations >= config.iterations) {
+      break
+    }
+  }
+
+  return {
+    results: results,
+    iterations: iterations,
+    info: {
+      lastBaseOccurrence: lastBaseOccurrence
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "test": "mocha test/*.spec.js",
-    "autotest": "./node_modules/.bin/supervisor -q -n exit -x npm test"
+    "autotest": "npx supervisor -q -n exit -x npm test"
   },
   "repository": {
     "type": "git",
@@ -33,7 +33,14 @@
   "homepage": "https://github.com/lfreneda/recurring#readme",
   "devDependencies": {
     "chai": "^4.1.2",
-    "mocha": "^4.1.0"
+    "eslint": "^6.8.0",
+    "eslint-config-standard": "^14.1.0",
+    "eslint-plugin-import": "^2.20.0",
+    "eslint-plugin-node": "^11.0.0",
+    "eslint-plugin-promise": "^4.2.1",
+    "eslint-plugin-standard": "^4.0.1",
+    "mocha": "^4.1.0",
+    "supervisor": "^0.12.0"
   },
   "dependencies": {
     "moment": "^2.20.1",

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -253,7 +253,6 @@ describe('lib/recurring', function () {
             let expectedResult = {
                 results: [
                     '2018-01-30',
-                    '2018-02-28',
                     '2018-03-30',
                     '2018-04-30',
                 ],
@@ -279,7 +278,7 @@ describe('lib/recurring', function () {
             let expectedResult = {
                 results: [
                     '2020-01-30',
-                    '2020-02-29',
+
                     '2020-03-30',
                     '2020-04-30',
                 ],
@@ -291,6 +290,95 @@ describe('lib/recurring', function () {
 
             assert.deepEqual(result, expectedResult);
         });
+
+        it('given options for monthly recurring every 1 month on day 31 (including February), result should be as expected', function () {
+
+            let result = recurring({
+                interval: 'M',
+                every: 1,
+                dayOfMonth: 31,
+                start: '2019-12-23',
+                end: '2020-05-23'
+            });
+
+            let expectedResult = {
+                results: [
+                    '2019-12-31',
+                    '2020-01-31',
+                    '2020-03-31'
+                ],
+                iterations: 5,
+                info: {
+                    lastBaseOccurrence: '2020-04-29'
+                }
+            };
+
+            assert.deepEqual(result, expectedResult)
+        });
+
+        it('given options for monthly recurring every 1 month on day 30 (including February on a leap year) skiping weekend, result should be as expected', function () {
+
+            let result = recurring({
+                interval: 'M',
+                every: 1,
+                dayOfMonth: 30,
+                start: '2019-12-23',
+                end: '2020-06-30',
+                options: {
+                    skipWeekend: true
+                }
+            });
+
+            let expectedResult = {
+                results: [
+                    '2019-12-30',
+                    '2020-01-30',
+                    '2020-03-30',
+                    '2020-04-30',
+                    '2020-06-01',
+                    '2020-06-30'
+                ],
+                iterations: 7,
+                info: {
+                    lastBaseOccurrence: '2020-06-29'
+                }
+            };
+
+            assert.deepEqual(result, expectedResult)
+        });
+
+        it('given options for monthly recurring every 1 month on day 31 (including February) skip weekend, result should be as expected', function () {
+
+            let result = recurring({
+                interval: 'M',
+                every: 1,
+                dayOfMonth: 31,
+                start: '2019-12-23',
+                end: '2020-10-23',
+                options: {
+                    skipWeekend: true
+                }
+            });
+
+            let expectedResult = {
+                results: [
+                    '2019-12-31',
+                    '2020-01-31',
+                    '2020-03-31',
+                    '2020-06-01',
+                    '2020-07-31',
+                    '2020-08-31'
+                ],
+                iterations: 10,
+                info: {
+                    lastBaseOccurrence: '2020-09-29'
+                }
+            };
+
+            assert.deepEqual(result, expectedResult)
+        });
+
+
     });
 
 


### PR DESCRIPTION
Anteriormente, se a configuração de pular fim de semana estivesse ativada e a recorrência fosse
mensal, dias que fossem final de semana era adicionado no resultado.