### PR TITLE
fix: recorrencias desconfigurado

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -20,23 +20,16 @@ exports = module.exports = function (config) {
   config.start = moment(config.start)
   config.end = config.end ? moment(config.end) : null
 
-  const occurrence = config.start
+  const occurrence = config.start.clone()
 
   if (config.dayOfMonth) {
-    while (true) {
-      if (occurrence.date() === config.dayOfMonth) {
-        break
-      }
-
+    while (occurrence.date() !== config.dayOfMonth) {
       occurrence.add(1, 'd')
     }
   }
 
   if (config.weekday || config.weekday === 0) {
-    while (true) {
-      if (occurrence.weekday() === config.weekday) {
-        break
-      }
+    while (occurrence.weekday() !== config.weekday) {
       occurrence.add(1, 'd')
     }
   }
@@ -48,30 +41,46 @@ exports = module.exports = function (config) {
   while (true) {
     iterations++
 
-    let result = occurrence
+    let result = occurrence.clone()
+
     if (config.dayOfMonth) {
       const expectedDate = moment(result).format('YYYY-MM-') + config.dayOfMonth.pad(2)
       result = moment(expectedDate)
     }
-    if (config.options.skipWeekend && result.isValid()) {
-      if (result.weekday() === 0) {
-        result = result.clone().add(1, 'd')
-      }
 
-      if (result.weekday() === 6) {
-        result = result.clone().add(2, 'd')
+    if (config.options.skipWeekend) {
+      if (config.interval === 'd') {
+        let daysToAdd = config.every
+        while (daysToAdd > 0) {
+          occurrence.add(1, 'd')
+          if (occurrence.weekday() !== 0 && occurrence.weekday() !== 6) {
+            daysToAdd--
+          }
+        }
+      } else if (config.interval === 'M') {
+        occurrence.add(config.every, 'M')
+        result.date(config.dayOfMonth)
+
+        if (result.weekday() === 0) {
+          result.add(1, 'd')
+        } else if (result.weekday() === 6) {
+          result.add(2, 'd')
+        }
       }
+    } else {
+      occurrence.add(config.every, config.interval)
     }
 
-    const formattedResult = result.format(config.options.format)
-    if (!_.contains(results, formattedResult) && result.isValid()) {
-      results.push(formattedResult)
+    if (result.isValid()) {
+      const formattedResult = result.format(config.options.format)
+      if (!_.contains(results, formattedResult)) {
+        results.push(formattedResult)
+      }
+
+      lastBaseOccurrence = result.format(config.options.format)
     }
 
-    lastBaseOccurrence = occurrence.format(config.options.format)
-    occurrence.add(config.every, config.interval)
-
-    if (config.end !== null && occurrence.isAfter(config.end)) {
+    if (config.end && occurrence.isAfter(config.end)) {
       break
     }
 

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -57,15 +57,100 @@ describe('lib/recurring', function () {
                     '2018-01-15',
                     '2018-01-17',
                     '2018-01-19',
-                    '2018-01-22',
                     '2018-01-23',
                     '2018-01-25',
                     '2018-01-29',
                     '2018-01-31'
                 ],
-                iterations: 11,
+                iterations: 8,
                 info: {
                     lastBaseOccurrence: '2018-01-31'
+                }
+            };
+
+            assert.deepEqual(result, expectedResult);
+        });
+
+        it('given options for daily recurring every 3 days ignoring weekends, result should be as expected', function () {
+
+            let result = recurring({
+                interval: 'd',
+                every: 3,
+                start: '2018-01-11',
+                end: '2018-02-01',
+                options: {
+                    skipWeekend: true
+                }
+            });
+
+            let expectedResult = {
+                results: [
+                    '2018-01-11',
+                    '2018-01-16',
+                    '2018-01-19',
+                    '2018-01-24',
+                    '2018-01-29',
+                    '2018-02-01'
+                ],
+                iterations: 6,
+                info: {
+                    lastBaseOccurrence: '2018-02-01'
+                }
+            };
+
+            assert.deepEqual(result, expectedResult);
+        });
+
+        it('given options for daily recurring every 4 days ignoring weekends, result should be as expected', function () {
+
+            let result = recurring({
+                interval: 'd',
+                every: 4,
+                start: '2018-01-11',
+                end: '2018-02-01',
+                options: {
+                    skipWeekend: true
+                }
+            });
+
+            let expectedResult = {
+                results: [
+                    '2018-01-11',
+                    '2018-01-17',
+                    '2018-01-23',
+                    '2018-01-29',
+                ],
+                iterations: 4,
+                info: {
+                    lastBaseOccurrence: '2018-01-29'
+                }
+            };
+
+            assert.deepEqual(result, expectedResult);
+        });
+
+        it('given options for daily recurring every 5 days ignoring weekends, result should be as expected', function () {
+
+            let result = recurring({
+                interval: 'd',
+                every: 5,
+                start: '2018-01-11',
+                end: '2018-02-01',
+                options: {
+                    skipWeekend: true
+                }
+            });
+
+            let expectedResult = {
+                results: [
+                    '2018-01-11',
+                    '2018-01-18',
+                    '2018-01-25',
+                    '2018-02-01',
+                ],
+                iterations: 4,
+                info: {
+                    lastBaseOccurrence: '2018-02-01'
                 }
             };
 
@@ -297,7 +382,7 @@ describe('lib/recurring', function () {
                 ],
                 iterations: 4,
                 info: {
-                    lastBaseOccurrence: '2018-04-28'
+                    lastBaseOccurrence: '2018-04-30'
                 }
             };
 
@@ -323,7 +408,7 @@ describe('lib/recurring', function () {
                 ],
                 iterations: 4,
                 info: {
-                    lastBaseOccurrence: '2020-04-29'
+                    lastBaseOccurrence: '2020-04-30'
                 }
             };
 
@@ -348,7 +433,7 @@ describe('lib/recurring', function () {
                 ],
                 iterations: 5,
                 info: {
-                    lastBaseOccurrence: '2020-04-29'
+                    lastBaseOccurrence: '2020-03-31'
                 }
             };
 
@@ -379,7 +464,7 @@ describe('lib/recurring', function () {
                 ],
                 iterations: 7,
                 info: {
-                    lastBaseOccurrence: '2020-06-29'
+                    lastBaseOccurrence: '2020-06-30'
                 }
             };
 
@@ -410,7 +495,7 @@ describe('lib/recurring', function () {
                 ],
                 iterations: 10,
                 info: {
-                    lastBaseOccurrence: '2020-09-29'
+                    lastBaseOccurrence: '2020-08-31'
                 }
             };
 


### PR DESCRIPTION
ajustada a lógica da biblioteca para que ela ignore os finais de semana apenas quando o intervalo é diário, em vez de mover para o próximo dia útil, isso porque alguns clientes estavam reclamando que, ao gerar um intervalo de 2 dias, acabava ficando com dias como 'segunda, terça e quinta' devido ao deslocamento do domingo para a segunda